### PR TITLE
Allow easier way to load matter config toml file

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -60,12 +60,23 @@ var isDefault = true;
 // Build the Quick Try UI using the config toml file. If external path is not specified, pick up the default config
 async function buildQuickTryUI() {
     const urlParams = new URLSearchParams(window.location.search);
-    var tomlFileURL = urlParams.get('flashConfigURL');
-    if(!tomlFileURL)
-        tomlFileURL = document.location.href + "/config/default_config.toml";
-    else
-        isDefault = false;
-
+    var tomlFileURL = "/config/rainmaker_config.toml"; // defaulting to rainmaker for now.
+    var solution = urlParams.get("solution");
+    if (solution){
+        if (solution.toLowerCase() == "matter")
+            // use the one published by the ci/cd job of matter on the github
+            tomlFileURL = "https://espressif.github.io/esp-matter/launchpad.toml"
+        else if(solution.toLowerCase() == "rainmaker")
+            // use the one bundled in the config
+            tomlFileURL = "/config/rainmaker_config.toml";
+    }
+    else {
+        var externalURL = urlParams.get('flashConfigURL');
+        if(externalURL){
+            tomlFileURL = externalURL;
+            isDefault = false;
+        }
+    }
     var xhr = new XMLHttpRequest();
     xhr.open('GET', tomlFileURL, true);
     xhr.send();
@@ -87,25 +98,6 @@ async function buildQuickTryUI() {
             catch (err){
                 alert ("Unsupported config version used -" + err.message)
             }
-
-            /*
-            const frameworks = config["esp_frameworks"];
-            if (frameworks) {
-                frameworkSelect.innerHTML = "";
-                frameworks.forEach(framework => {
-                    //var frameworkOption = framework.split(':');
-                    var option = document.createElement("option");
-                    option.value = framework.toLowerCase();
-                    option.text = framework;
-                    frameworkSelect.appendChild(option);
-                });
-            }*/
-
-            //if(frameworkSelect)
-            //{
-                //populateDeviceTypes(config[frameworkSelect.value]);
-                //populateSupportedChipsets(config[frameworkSelect.value]);
-            //}
 
             return config;
         }


### PR DESCRIPTION
ESP Matter team has configured their CI job to generate example binaries and config toml file which can used for launchpad UI.
We should have a simpler way to load these from our internal product teams

Added a query parameter support 'solution' which expects values as either 'matter' or 'rainmaker'. Defaults to rainmaker config otherwise.
/?solution=matter

Users can still use their own config toml file by passing the flashConfigURL query param