### PR TITLE
feat(deps): update esptool-js to 0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
 			"name": "esp-launchpad",
 			"dependencies": {
 				"crypto-js": "^4.1.1",
-				"esptool-js": "^0.2.1",
+				"esptool-js": "^0.2.2",
 				"toml-js": "^0.0.8",
 				"xterm": "^4.17.0",
 				"xterm-addon-fit": "^0.5.0"
@@ -19,9 +19,9 @@
 			"integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
 		},
 		"node_modules/esptool-js": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.2.1.tgz",
-			"integrity": "sha512-M2UteDiWrllJOBWLHwNRGaEAkDEHAG6FH6LdsTxJPUFLxbH/xwFMQEudiVH+REZc0FGfvY0YntVMes+HkZBeKw==",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.2.2.tgz",
+			"integrity": "sha512-Lsw/PEqxzNf6lTxEzH4jRBlUiFo0l0sfTijpJuDrtqoAoR2tvwqwviuWp0L2UPQzHUNVj+PgHKGLYycRkJ/iZw==",
 			"dependencies": {
 				"pako": "^2.1.0",
 				"tslib": "^2.4.1"
@@ -63,9 +63,9 @@
 			"integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
 		},
 		"esptool-js": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.2.1.tgz",
-			"integrity": "sha512-M2UteDiWrllJOBWLHwNRGaEAkDEHAG6FH6LdsTxJPUFLxbH/xwFMQEudiVH+REZc0FGfvY0YntVMes+HkZBeKw==",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.2.2.tgz",
+			"integrity": "sha512-Lsw/PEqxzNf6lTxEzH4jRBlUiFo0l0sfTijpJuDrtqoAoR2tvwqwviuWp0L2UPQzHUNVj+PgHKGLYycRkJ/iZw==",
 			"requires": {
 				"pako": "^2.1.0",
 				"tslib": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "esp-launchpad",
 	"dependencies": {
 		"crypto-js": "^4.1.1",
-		"esptool-js": "^0.2.1",
+		"esptool-js": "^0.2.2",
 		"toml-js": "^0.0.8",
 		"xterm": "^4.17.0",
 		"xterm-addon-fit": "^0.5.0"


### PR DESCRIPTION
* Update esptool-js to [release 0.2.2](https://github.com/espressif/esptool-js/releases/tag/v0.2.2):
  * [Update stubs from esptool.py v4.6.1](https://github.com/espressif/esptool-js/pull/98)

Over at https://github.com/espressif/esp-launchpad/issues/18#issuecomment-1633964597 it was reported that this fixes #18.