### PR TITLE
Update the IOS app URL for matter solution.

### DIFF
--- a/config/default_config.toml
+++ b/config/default_config.toml
@@ -2,7 +2,7 @@ esp_toml_version = 1.0
 
 firmware_images_url = "https://adwait-esp.github.io/flasher/images/"
 
-supported_apps = ["Matter-AllClustersApp-TE9", "Matter-AllClustersApp-M5Stack-TE9", "Matter-LightingApp-TE9", "RainMaker-Fan", "RainMaker-GPIO", "RainMaker-Homekit Switch", "RainMaker-Led Light", "RainMaker-Multi Device", "RainMaker-Switch", "RainMaker-Temperature Sensor"]
+supported_apps = ["Matter-AllClustersApp-TE9", "Matter-AllClustersApp-M5Stack-TE9", "Matter-LightingApp-TE9", "RainMaker-Fan", "RainMaker-GPIO", "RainMaker-Homekit-Switch", "RainMaker-Led-Light", "RainMaker-Multi-Device", "RainMaker-Switch", "RainMaker-Temperature-Sensor"]
 
 
 [RainMaker-Fan]
@@ -21,7 +21,7 @@ image.esp32-c3 = "esp32c3_rainmaker_gpio_merged.bin"
 android_app_url = "https://play.google.com/store/apps/details?id=com.espressif.rainmaker"
 ios_app_url = "https://apps.apple.com/app/esp-rainmaker/id1497491540"
 
-[RainMaker-Homekit Switch]
+[RainMaker-Homekit-Switch]
 chipsets = ["ESP32", "ESP32-S2", "ESP32-C3"]
 image.esp32 = "esp32_rainmaker_homekit_switch_merged.bin"
 image.esp32-s2 = "esp32s2_rainmaker_homekit_switch_merged.bin"
@@ -29,7 +29,7 @@ image.esp32-c3 = "esp32c3_rainmaker_homekit_switch_merged.bin"
 android_app_url = "https://play.google.com/store/apps/details?id=com.espressif.rainmaker"
 ios_app_url = "https://apps.apple.com/app/esp-rainmaker/id1497491540"
 
-[RainMaker-Led Light]
+[RainMaker-Led-Light]
 chipsets = ["ESP32", "ESP32-S2", "ESP32-C3"]
 image.esp32 = "esp32_rainmaker_led_light_merged.bin"
 image.esp32-s2 = "esp32s2_rainmaker_led_light_merged.bin"
@@ -37,7 +37,7 @@ image.esp32-c3 = "esp32c3_rainmaker_led_light_merged.bin"
 android_app_url = "https://play.google.com/store/apps/details?id=com.espressif.rainmaker"
 ios_app_url = "https://apps.apple.com/app/esp-rainmaker/id1497491540"
 
-[RainMaker-Multi Device]
+[RainMaker-Multi-Device]
 chipsets = ["ESP32", "ESP32-S2", "ESP32-C3"]
 image.esp32 = "esp32_rainmaker_multi_device_merged.bin"
 image.esp32-s2 = "esp32s2_rainmaker_multi_device_merged.bin"
@@ -53,7 +53,7 @@ image.esp32-c3 = "esp32c3_rainmaker_switch_merged.bin"
 android_app_url = "https://play.google.com/store/apps/details?id=com.espressif.rainmaker"
 ios_app_url = "https://apps.apple.com/app/esp-rainmaker/id1497491540"
 
-[RainMaker-Temperature Sensor]
+[RainMaker-Temperature-Sensor]
 chipsets = ["ESP32", "ESP32-S2", "ESP32-C3"]
 image.esp32 = "esp32_rainmaker_temperature_sensor_merged.bin"
 image.esp32-s2 = "esp32s2_rainmaker_temperature_sensor_merged.bin"
@@ -65,18 +65,18 @@ ios_app_url = "https://apps.apple.com/app/esp-rainmaker/id1497491540"
 chipsets = ["ESP32", "ESP32-C3"]
 image.esp32 = "esp32_matter_all-clusters-app.bin"
 image.esp32-c3 = "esp32c3_matter_all-clusters-app.bin"
-ios_app_url = "https://apps.apple.com/app/espressif-matter/id1604739172?platform=iphone"
+ios_app_url = "https://apps.apple.com/app/esp-rainmaker/id1497491540"
 android_app_url = ""
 
 [Matter-AllClustersApp-M5Stack-TE9]
 chipsets = ["ESP32"]
 image.esp32 = "m5stack_matter_all-clusters-app.bin"
-ios_app_url = "https://apps.apple.com/app/espressif-matter/id1604739172?platform=iphone"
+ios_app_url = "https://apps.apple.com/app/esp-rainmaker/id1497491540"
 android_app_url = ""
 
 [Matter-LightingApp-TE9]
 chipsets = ["ESP32", "ESP32-C3"]
 image.esp32 = "esp32_matter_lighting-app.bin"
 image.esp32-c3 = "esp32c3_matter_lighting-app.bin"
-ios_app_url = "https://apps.apple.com/app/espressif-matter/id1604739172?platform=iphone"
+ios_app_url = "https://apps.apple.com/app/esp-rainmaker/id1497491540"
 android_app_url = ""

--- a/config/matter_config.toml
+++ b/config/matter_config.toml
@@ -9,18 +9,18 @@ supported_apps = ["Matter-AllClustersApp-TE9", "Matter-AllClustersApp-M5Stack-TE
 chipsets = ["ESP32", "ESP32-C3"]
 image.esp32 = "esp32_matter_all-clusters-app.bin"
 image.esp32-c3 = "esp32c3_matter_all-clusters-app.bin"
-ios_app_url = "https://apps.apple.com/app/espressif-matter/id1604739172?platform=iphone"
+ios_app_url = "https://apps.apple.com/app/esp-rainmaker/id1497491540"
 android_app_url = ""
 
 [Matter-AllClustersApp-M5Stack-TE9]
 chipsets = ["ESP32"]
 image.esp32 = "m5stack_matter_all-clusters-app.bin"
-ios_app_url = "https://apps.apple.com/app/espressif-matter/id1604739172?platform=iphone"
+ios_app_url = "https://apps.apple.com/app/esp-rainmaker/id1497491540"
 android_app_url = ""
 
 [Matter-LightingApp-TE9]
 chipsets = ["ESP32", "ESP32-C3"]
 image.esp32 = "esp32_matter_lighting-app.bin"
 image.esp32-c3 = "esp32c3_matter_lighting-app.bin"
-ios_app_url = "https://apps.apple.com/app/espressif-matter/id1604739172?platform=iphone"
+ios_app_url = "https://apps.apple.com/app/esp-rainmaker/id1497491540"
 android_app_url = ""

--- a/config/rainmaker_config.toml
+++ b/config/rainmaker_config.toml
@@ -2,7 +2,7 @@ esp_toml_version = 1.0
 
 firmware_images_url = "https://adwait-esp.github.io/flasher/images/"
 
-supported_apps = ["RainMaker-Fan", "RainMaker-GPIO", "RainMaker-Homekit Switch", "RainMaker-Led Light", "RainMaker-Multi Device", "RainMaker-Switch", "RainMaker-Temperature Sensor"]
+supported_apps = ["RainMaker-Fan", "RainMaker-GPIO", "RainMaker-Homekit-Switch", "RainMaker-Led-Light", "RainMaker-Multi-Device", "RainMaker-Switch", "RainMaker-Temperature-Sensor"]
 
 
 [RainMaker-Fan]
@@ -21,7 +21,7 @@ image.esp32-c3 = "esp32c3_rainmaker_gpio_merged.bin"
 android_app_url = "https://play.google.com/store/apps/details?id=com.espressif.rainmaker"
 ios_app_url = "https://apps.apple.com/app/esp-rainmaker/id1497491540"
 
-[RainMaker-Homekit Switch]
+[RainMaker-Homekit-Switch]
 chipsets = ["ESP32", "ESP32-S2", "ESP32-C3"]
 image.esp32 = "esp32_rainmaker_homekit_switch_merged.bin"
 image.esp32-s2 = "esp32s2_rainmaker_homekit_switch_merged.bin"
@@ -29,7 +29,7 @@ image.esp32-c3 = "esp32c3_rainmaker_homekit_switch_merged.bin"
 android_app_url = "https://play.google.com/store/apps/details?id=com.espressif.rainmaker"
 ios_app_url = "https://apps.apple.com/app/esp-rainmaker/id1497491540"
 
-[RainMaker-Led Light]
+[RainMaker-Led-Light]
 chipsets = ["ESP32", "ESP32-S2", "ESP32-C3"]
 image.esp32 = "esp32_rainmaker_led_light_merged.bin"
 image.esp32-s2 = "esp32s2_rainmaker_led_light_merged.bin"
@@ -37,7 +37,7 @@ image.esp32-c3 = "esp32c3_rainmaker_led_light_merged.bin"
 android_app_url = "https://play.google.com/store/apps/details?id=com.espressif.rainmaker"
 ios_app_url = "https://apps.apple.com/app/esp-rainmaker/id1497491540"
 
-[RainMaker-Multi Device]
+[RainMaker-Multi-Device]
 chipsets = ["ESP32", "ESP32-S2", "ESP32-C3"]
 image.esp32 = "esp32_rainmaker_multi_device_merged.bin"
 image.esp32-s2 = "esp32s2_rainmaker_multi_device_merged.bin"
@@ -53,7 +53,7 @@ image.esp32-c3 = "esp32c3_rainmaker_switch_merged.bin"
 android_app_url = "https://play.google.com/store/apps/details?id=com.espressif.rainmaker"
 ios_app_url = "https://apps.apple.com/app/esp-rainmaker/id1497491540"
 
-[RainMaker-Temperature Sensor]
+[RainMaker-Temperature-Sensor]
 chipsets = ["ESP32", "ESP32-S2", "ESP32-C3"]
 image.esp32 = "esp32_rainmaker_temperature_sensor_merged.bin"
 image.esp32-s2 = "esp32s2_rainmaker_temperature_sensor_merged.bin"


### PR DESCRIPTION
- Update the IOS app URL for matter solution. Now that a single ESP Rainmaker IOS App supports Rainmaker plus matter fabric devices.
- Also removed spaces in the app names, replaced with hiphen.