### PR TITLE
Fix: Added Check For Empty README.md File [ minimal-launchpad ]

### DIFF
--- a/minimal-launchpad/minimal_ui_index.js
+++ b/minimal-launchpad/minimal_ui_index.js
@@ -83,14 +83,17 @@ function MDtoHtml() {
             return response.text();
         }).then(result => {
             let htmlText = converter.makeHtml(result);
-            message.innerHTML = htmlText;
-            consoleStartButton.click()
-            message.style.display = "block";
-            productInfoContainer.classList.add("col-6", "slide-up");
-            terminalContainer.classList.remove("col-12", "fade-in");
-            terminalContainer.classList.add("col-6", "slide-right");
-            utilities.resizeTerminal(fitAddon);
-
+            if (htmlText) {
+                message.innerHTML = htmlText;
+                message.style.display = "block";
+                productInfoContainer.classList.add("col-6", "slide-up");
+                terminalContainer.classList.remove("col-12", "fade-in");
+                terminalContainer.classList.add("col-6", "slide-right");
+                utilities.resizeTerminal(fitAddon);
+            } else {
+                message.style.display = "none";
+            }
+            consoleStartButton.click();
         })
     } catch (error) {
         message.style.display = "none";


### PR DESCRIPTION
# What This PR Does ? [ minimal-launchpad ]

- It introduces a check to handle an empty README.md file that was causing UI distortion.
- It corrects the display of results, showing only the **terminalContainer** and hiding the **productInfoContainer**.