### PR TITLE
Added Functional Call To "erase_flash" In Minimal Launchpad

### DIFF
--- a/minimal-launchpad/minimal_ui_index.js
+++ b/minimal-launchpad/minimal_ui_index.js
@@ -66,7 +66,7 @@ async function downloadAndFlash() {
             flashSize: "keep",
             flashMode: undefined,
             flashFreq: undefined,
-            eraseAll: false,
+            eraseAll: true, // Always erasing before flash
             compress: true,
         };
         await esploader.write_flash(flashOptions);


### PR DESCRIPTION
# What Does This PR Do ?
- This PR adds a call to **esploader.erase_flash** to remove existing binaries from the chipset before initiating the flashing of new binaries.
<img width="1552" alt="image" src="https://github.com/espressif/esp-launchpad/assets/90703337/e6ec691d-6a01-4f4b-b638-267023ce145a">

# Test Link ?
https://rushikeshpatange.github.io/esp-launchpad/minimal-launchpad/