### PR TITLE
Feat/CLI : Add Support For CLI In Minimal-Launchpad

### DIFF
--- a/minimal-launchpad/index.html
+++ b/minimal-launchpad/index.html
@@ -71,6 +71,9 @@
                             </div>
                         </div>
                         <div id="terminal"><span class="devicelog">Device logs</span></div>
+                        <div id="commandForm" style="display: none;">
+                            <input type="text" autocomplete="off" class="form-control rounded-0 shadow-none" id="commandInput" placeholder="Type Your Command And Press Enter">
+                        </div>
                 </div>
             </div>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
 			"name": "esp-launchpad",
 			"dependencies": {
 				"crypto-js": "^4.1.1",
-				"esptool-js": "^0.3.0",
+				"esptool-js": "^0.3.2",
 				"smol-toml": "^1.1.2",
 				"xterm": "^4.17.0",
 				"xterm-addon-fit": "^0.5.0"
@@ -19,9 +19,9 @@
 			"integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
 		},
 		"node_modules/esptool-js": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.3.0.tgz",
-			"integrity": "sha512-DQQt/hyh45VvnDv6/lBIhUq9cD7ajZa9x3s/BftvT/zpQN2v5ZnRnBAQsNL0RXwUIGyJoI7MgPp7iGyq0Z2gJg==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.3.2.tgz",
+			"integrity": "sha512-hA58j6wxm143MTa1ZkM/uaDsaF2U+/2sdcoPVz5G78o7wENqzOb5KnHfhPGXK8mbhhYnmC7JXGhZ7wfgeB8DmQ==",
 			"dependencies": {
 				"pako": "^2.1.0",
 				"tslib": "^2.4.1"
@@ -67,9 +67,9 @@
 			"integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
 		},
 		"esptool-js": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.3.0.tgz",
-			"integrity": "sha512-DQQt/hyh45VvnDv6/lBIhUq9cD7ajZa9x3s/BftvT/zpQN2v5ZnRnBAQsNL0RXwUIGyJoI7MgPp7iGyq0Z2gJg==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.3.2.tgz",
+			"integrity": "sha512-hA58j6wxm143MTa1ZkM/uaDsaF2U+/2sdcoPVz5G78o7wENqzOb5KnHfhPGXK8mbhhYnmC7JXGhZ7wfgeB8DmQ==",
 			"requires": {
 				"pako": "^2.1.0",
 				"tslib": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "esp-launchpad",
 	"dependencies": {
 		"crypto-js": "^4.1.1",
-		"esptool-js": "^0.3.0",
+		"esptool-js": "^0.3.2",
 		"smol-toml": "^1.1.2",
 		"xterm": "^4.17.0",
 		"xterm-addon-fit": "^0.5.0"


### PR DESCRIPTION
# What Does This PR Do ?
This PR adds support to interact with flashed firmware by passing commands through CLI in minimal-launchpad, which get enabled when passed TOML has following field: (i.e.,  portConnectionOptions)

```
** Note: This is just an example **

[[portConnectionOptions]]
baudRate = 48600 (number)
dataBits = 8 (number)
stopBits = 1 (number)
parity = "none" (ParityType)
flowControl = "none" (FlowControlType)
```
The options below to portConnectionOptions are passed while opening the port of the device. You can find more about serialOptions [here](https://wicg.github.io/serial/#serialoptions-dictionary)

# Test Link ?
You can check the working demo from following URL:
```
https://esp-launchpad-cli.netlify.app/minimal-launchpad/?flashConfigURL=<YOUR_TOML_FILE_LINK_WITH_ABOVE_FIELD>
```