### PR TITLE
Fix: Resolve Issue With Passing Correct Variable Type Of Baudrate And Offset.

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -258,7 +258,7 @@ async function connectToDevice() {
     try {
         const loaderOptions = {
             transport,
-            baudrate: baudrates.value,
+            baudrate: parseInt(baudrates.value),
             terminal: espLoaderTerminal
         };
         esploader = new ESPLoader(loaderOptions);

--- a/minimal-launchpad/minimal_ui_index.js
+++ b/minimal-launchpad/minimal_ui_index.js
@@ -81,7 +81,7 @@ async function downloadAndFlash() {
     let fileArr = []
     for (let index = 0; index < imagePartsArray.length; index++) {
         let data = await utilities.getImageData(imagePartsArray[index]);
-        fileArr.push({ data: data, address: imagePartsOffsetArray[index] });
+        fileArr.push({ data: data, address: parseInt(imagePartsOffsetArray[index]) });
     }
     try {
         const flashOptions = {
@@ -218,7 +218,7 @@ async function connectToDevice() {
         if (config.portConnectionOptions?.length) {
             loaderOptions = {
                 transport: transport,
-                baudrate: config.portConnectionOptions[0]?.baudRate,
+                baudrate: parseInt(config.portConnectionOptions[0]?.baudRate),
                 terminal: espLoaderTerminal,
                 serialOptions,
             };
@@ -298,7 +298,7 @@ consoleStartButton.onclick = async () => {
         }
     }
     if (config.portConnectionOptions?.length) {
-        await transport.connect(config.portConnectionOptions[0]?.baudRate, serialOptions);
+        await transport.connect(parseInt(config.portConnectionOptions[0]?.baudRate), serialOptions);
     } else {
         await transport.connect();
     }


### PR DESCRIPTION
# What Does This PR Do?
- It ensures that baudrate and offset/address are of the required type.
- It resolves the issue of incorrectly printing offsets during flashing. Previously, the offset/address were passed as strings instead of numbers, causing problems with the printing of offsets.

# Screen Shots ?
Incorrectly Printed Offsets:
![image](https://github.com/espressif/esp-launchpad/assets/90703337/c66e865e-487b-4d17-a72d-537f3e2f6436)

Test link ?

- [Incorrectly Printed Offsets](https://espressif.github.io/esp-launchpad/minimal-launchpad/?flashConfigURL=https://raw.githubusercontent.com/RushikeshPatange/EZC_toml/main/EZC/config.toml)
- [Fix](https://rushikeshpatange.github.io/esp-launchpad/minimal-launchpad/?flashConfigURL=https://raw.githubusercontent.com/RushikeshPatange/EZC_toml/main/EZC/config.toml)