### PR TITLE
Support: Add Support Of Proper Console Baudrate For Chips With 26 MHz  Frequency

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -21,3 +21,5 @@ android_app_url = ""
 ios_app_url = ""
 # Optional: URL of the Markdown file for additional information about the app
 readme.text = "<URL to your Markdown file>"
+# Optional: Supported console baudrate for app firmware (default value is 115200)
+console_baudrate = <SUPPORTED_CONSOLE_BAUDRATE>

--- a/minimal-launchpad/minimal_ui_index.js
+++ b/minimal-launchpad/minimal_ui_index.js
@@ -46,6 +46,7 @@ let device = null;
 let transport;
 let chip = "default";
 let chipDesc = "default";
+let consoleBaudrateFromToml;
 let esploader;
 let connected = false;
 let resizeTimeout = false;
@@ -92,7 +93,7 @@ async function downloadAndFlash() {
             eraseAll: true, // Always erasing before flash
             compress: true,
         };
-        await esploader.write_flash(flashOptions);
+        await esploader.writeFlash(flashOptions);
     } catch (error) {
         errorTroubleshootModalToggleButton.click();
         waitButton.style.display = "none";
@@ -232,14 +233,14 @@ async function connectToDevice() {
         esploader = new ESPLoader(loaderOptions);
         connected = true;
 
-        chipDesc = await esploader.main_fn();
+        chipDesc = await esploader.main();
         clearTimeout(deviceConnectionTimeout);
         if (errorTroubleshootModal.classList.contains("show")) {
             errorTroubleshootModalToggleButton.click();
         }
         chip = esploader.chip.CHIP_NAME;
 
-        await esploader.flash_id();
+        await esploader.flashId();
     } catch (error) {
         clearTimeout(deviceConnectionTimeout);
         if (!errorTroubleshootModal.classList.contains("show")) {
@@ -300,7 +301,8 @@ consoleStartButton.onclick = async () => {
     if (config.portConnectionOptions?.length) {
         await transport.connect(parseInt(config.portConnectionOptions[0]?.baudRate), serialOptions);
     } else {
-        await transport.connect();
+        consoleBaudrateFromToml = config[config['supported_apps'][0]].console_baudrate;
+        await transport.connect(consoleBaudrateFromToml);
     }
     await transport.setDTR(false);
     await new Promise(resolve => setTimeout(resolve, 100));

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,52 @@
 			"name": "esp-launchpad",
 			"dependencies": {
 				"crypto-js": "^4.1.1",
-				"esptool-js": "^0.3.2",
+				"esptool-js": "^0.4.1",
 				"smol-toml": "^1.1.2",
 				"xterm": "^4.17.0",
 				"xterm-addon-fit": "^0.5.0"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
+		},
+		"node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
 			}
 		},
 		"node_modules/crypto-js": {
@@ -19,13 +61,33 @@
 			"integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
 		},
 		"node_modules/esptool-js": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.3.2.tgz",
-			"integrity": "sha512-hA58j6wxm143MTa1ZkM/uaDsaF2U+/2sdcoPVz5G78o7wENqzOb5KnHfhPGXK8mbhhYnmC7JXGhZ7wfgeB8DmQ==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.4.1.tgz",
+			"integrity": "sha512-JhPHyjBncwnZDmOWxzjCQV5e6m1qP9kXPsZy5Zn/cu4tBOfPL8McncIzNVCzmLn7Jvgi06Jg09OK2HrkyMSboA==",
 			"dependencies": {
+				"buffer": "^6.0.3",
 				"pako": "^2.1.0",
 				"tslib": "^2.4.1"
 			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
 		},
 		"node_modules/pako": {
 			"version": "2.1.0",
@@ -42,9 +104,9 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/xterm": {
 			"version": "4.19.0",
@@ -61,19 +123,39 @@
 		}
 	},
 	"dependencies": {
+		"base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+		},
+		"buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"requires": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
 		"crypto-js": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
 			"integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
 		},
 		"esptool-js": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.3.2.tgz",
-			"integrity": "sha512-hA58j6wxm143MTa1ZkM/uaDsaF2U+/2sdcoPVz5G78o7wENqzOb5KnHfhPGXK8mbhhYnmC7JXGhZ7wfgeB8DmQ==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.4.1.tgz",
+			"integrity": "sha512-JhPHyjBncwnZDmOWxzjCQV5e6m1qP9kXPsZy5Zn/cu4tBOfPL8McncIzNVCzmLn7Jvgi06Jg09OK2HrkyMSboA==",
 			"requires": {
+				"buffer": "^6.0.3",
 				"pako": "^2.1.0",
 				"tslib": "^2.4.1"
 			}
+		},
+		"ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
 		},
 		"pako": {
 			"version": "2.1.0",
@@ -86,9 +168,9 @@
 			"integrity": "sha512-opeweddRVyIFjnNPmEodUn4LlVeiZNE3OZ3QiLvyC/pWxNgW3z02oCTVOFVgYI1w1sSO4nifFCcvw1ADOMs5ag=="
 		},
 		"tslib": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"xterm": {
 			"version": "4.19.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "esp-launchpad",
 	"dependencies": {
 		"crypto-js": "^4.1.1",
-		"esptool-js": "^0.3.2",
+		"esptool-js": "^0.4.1",
 		"smol-toml": "^1.1.2",
 		"xterm": "^4.17.0",
 		"xterm-addon-fit": "^0.5.0"


### PR DESCRIPTION
# What Does this MR do ? 
- Upgrade esptool-js version.
- Handle breaking API changes caused due to upgradation.
- Add support for proper console baudrate for chips with 26 MHz frequency.
- Add support of providing console baudrate through TOML.

# Test Link
You can test the changes by connecting your C2 Devkit to the launchpad [here](https://rushikeshpatange.github.io/esp-launchpad/) :-)