### PR TITLE
Fix(minimal-launchpad): Fix Slower Flashing of Expresslink Chips

### DIFF
--- a/minimal-launchpad/minimal_ui_index.js
+++ b/minimal-launchpad/minimal_ui_index.js
@@ -215,21 +215,23 @@ async function connectToDevice() {
     spinner.style.alignItems = "center";
 
     try {
+        const commonLoaderOptions = {
+            transport: transport,
+            baudrate: 460800,
+            terminal: espLoaderTerminal,
+        };
+
         let loaderOptions;
+
         if (config.portConnectionOptions?.length) {
             loaderOptions = {
-                transport: transport,
-                baudrate: parseInt(config.portConnectionOptions[0]?.baudRate),
-                terminal: espLoaderTerminal,
+                ...commonLoaderOptions,
                 serialOptions,
             };
         } else {
-            loaderOptions = {
-                transport: transport,
-                baudrate: 460800,
-                terminal: espLoaderTerminal,
-            };
+            loaderOptions = commonLoaderOptions;
         }
+
         esploader = new ESPLoader(loaderOptions);
         connected = true;
 


### PR DESCRIPTION
# What Does This PR Do ?
- Minimal-launchpad now uses common default baudrate to flash expresslink chips as like other chips rather than using baudrate coming from toml  in portConnectionOptions objects array which was lesser than the default one, making it slower to flash expresslink chips.

## Test Link ?
You can test the above fix [here](https://rushikeshpatange.github.io/esp-launchpad/minimal-launchpad/?flashConfigURL) by providing **supported expresslink TOML** to flashConfigURL parameter.

How you can verify the baudrate has been set to default value ?
- You will see one log in console saying **Changing baudrate to 460800**