### PR TITLE
Fix: Rename Console Baudrate Key

### DIFF
--- a/minimal-launchpad/minimal_ui_index.js
+++ b/minimal-launchpad/minimal_ui_index.js
@@ -301,7 +301,7 @@ consoleStartButton.onclick = async () => {
         }
     }
     if (config.portConnectionOptions?.length) {
-        await transport.connect(parseInt(config.portConnectionOptions[0]?.baudRate), serialOptions);
+        await transport.connect(parseInt(config.portConnectionOptions[0]?.console_baudrate), serialOptions);
     } else {
         consoleBaudrateFromToml = config[config['supported_apps'][0]].console_baudrate;
         await transport.connect(consoleBaudrateFromToml);


### PR DESCRIPTION
# What Does This PR Do ?
-  Rename Console Baudrate Key  from baudRate to console_baudrate_key, come's under portConnectionOptions of ExL TOML file

## Test link ?
You can test the above changes [here](https://esp-launchpad.netlify.app/minimal-launchpad/?flashConfigURL=) by providing ExL TOML to flashConfigURL query param.