### PR TITLE
feat(launchpad): add launchpad support devkit and readme

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -15,11 +15,18 @@ config_readme_url = "<APP_CONFIG_README_FILE_URL>"
 
 [YOUR_FIRMWARE_APP_NAME]
 # ESP32 Chipsets for which you have a supported Firmware App. Define a property for each supported chipset in the given format.
-chipsets = ["ESP32", "ESP32-S2", "ESP32-C3"]
+chipsets = ["ESP32", "ESP32-S2", "ESP32-C3", "ESP32-S3"]
+# Optional: Set development board for chip model.
+developKits.esp32-s3 = ["esp32-s3-box", "esp32-s3-box3"]
 # Configure the name of the binary file
 image.esp32 = "SINGLE_BIN_FOR_ESP32.bin"
 image.esp32-s2 = "SINGLE_BIN_FOR_ESP32-S2.bin"
 image.esp32-c3 = "SINGLE_BIN_FOR_ESP32-C3.bin"
+# Optinal: Configure the name of the image file for development board. Under this configuration, image.esp32-s3 will become invalid..
+image.esp32-s3-box = "SINGLE_BIN_FOR_ESP32-S3-BOX.bin"
+image.esp32-s3-box3 = "SINGLE_BIN_FOR_ESP32-S3-BOX3.bin"
+# Optional: A brief introduction to this app.
+description = "Description of the firmware app"
 # Optional: Phone APP URLs if any for Playstores
 android_app_url = ""
 ios_app_url = ""

--- a/css/custom.css
+++ b/css/custom.css
@@ -69,7 +69,7 @@
 
 .navbar-nav .nav-item .icon {
     opacity: 0.8;
-} 
+}
 
 .navbar-nav .nav-item.active .icon
 .navbar-nav .icon:hover {
@@ -146,7 +146,7 @@ footer {
 }
 
 .form .field-container .field select {
-    
+
     padding: 0.5em 3.5em 0.5em 1em;
     border: 1px solid var(--bs-gray-600);
     border-radius: 5px;
@@ -177,7 +177,7 @@ footer {
 }
 
 .app-button.submit-form-button {
-    
+
 }
 
 .main-page-tab-panel {
@@ -211,7 +211,7 @@ td img {
 }
 
 .xterm .xterm-viewport {
-    width: initial !important; 
+    width: initial !important;
 }
 
 /* About sections css */
@@ -254,10 +254,23 @@ td img {
     display: none;
 }
 
+.appdescription-text {
+    max-width: 25rem;
+    max-height: 30rem;
+    word-wrap: break-word;
+}
+
 .appinfocontainer {
-  max-height: 400px;
-  overflow-y: auto;
-  margin-top: 3rem;
+    max-height: 600px;
+    overflow-y: auto;
+    margin-top: 3rem;
+    width: 100%;
+}
+
+.appinfo-flash-container {
+    max-height: 600px;
+    overflow-y: auto;
+    margin-top: 3rem;
 }
 
 .app-config-info-container {

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
                                 <span>DIY</span>
                             </button>
                         </li>
-                        
+
                         <li class="nav-item">
                             <button class="nav-link icon-button" id="connectButton">
                                 <img src="assets/icons/connect.png" class="icon" />
@@ -127,7 +127,7 @@
                                 <span>Disconnect</span>
                             </button>
                         </li>
-                        
+
                         <li class="nav-item" data-role="nav-menu-tab" data-target-tab-panel-id="console">
                             <button class="nav-link icon-button" id="v-pills-console-tab">
                                 <img src="assets/icons/console.png" class="icon" />
@@ -200,10 +200,39 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="field-container" id ="developKitsContainer" style="display: none">
+                            <label>
+                                ESP Develop Kits
+                            </label>
+                            <div class="field">
+                                <div id="developKits">
+                                    <div class="form-check-inline">
+                                        <label class="form-check-label" for="radio3">ESP32-S3-DevKits&nbsp;
+                                            <input type="radio" checked class="form-check-input" name="developKitsType" id="radio3" value="">
+                                        </label>
+                                    </div>
+                                    <div class="form-check-inline">
+                                        <label class="form-check-label" for="radio4">ESP32-S3-DevKits&nbsp;
+                                            <input type="radio" class="form-check-input" name="developKitsType" id="radio4" value="">
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="field-container" id="appDescriptionContainer" style="display: none; align-items: baseline;">
+                            <label>
+                                Application Description
+                            </label>
+                            <span class="appdescription-text" id="appDescription">
+                            </span>
+                        </div>
                         <div class="field-container">
                             <div class="field-container" title="Click on 'Connect' button in top Menu" style="display:inline-block" data-toggle="tooltip" id="flashWrapper">
                                 <button class="app-button submit-form-button btn btn-outline-dark" id="flashButton" disabled>Flash</button>
                             </div>
+                        </div>
+                        <div class="appinfocontainer col-6" id="appInfoContainer" style="display:none;">
+                            <div id="appInfo"></div>
                         </div>
                     </div>
                     <div class="card text-dark bg-light app-config-info-container" id="appConfigInfoContainer" style="display: none;">
@@ -239,9 +268,9 @@
         <div class="container tabs-section main-page-tab-panel" data-tab-panel-id="diy">
             <h5 class="pt-4 pb-2 lh-lg">Choose your own built firmware image from the local storage to flash and use.</h5>
                 <br>
-                <input class="btn btn-danger btn-sm" type="button" id="eraseButton" value="Erase Flash" data-toggle="tooltip" 
+                <input class="btn btn-danger btn-sm" type="button" id="eraseButton" value="Erase Flash" data-toggle="tooltip"
             data-placement="top" title="Erase firmware on your device"/>
-                
+
                 <div class="alert alert-danger alert-dismissible fade-in-down" id="alertDiv" style="display:none; margin-top:10px">
                     <a href="#" class="close" aria-label="close" onclick="$('.alert').hide()">&times;</a>
                     <span id="alertmsg"></span>
@@ -277,11 +306,11 @@
         </div>
         <!-- DIY tab content - end -->
 
-        <!-- Console tab content - start -->    
+        <!-- Console tab content - start -->
         <div class="container main-page-tab-panel" data-tab-panel-id="console">
             <div class="row" id="consolePageWrapper">
-                <div class="appinfocontainer col-6" id="appInfoContainer" style="display:none;">
-                    <div id="appInfo"></div>
+                <div class="appinfo-flash-container col-6" id="appInfoFlashContainer" style="display:none;">
+                    <div id="appInfoFlash"></div>
                 </div>
                 <div class="col-12 fade-in-down" id="terminalContainer" style="display:none;">
                     <div class="button-container text-end mb-sm-3">
@@ -295,9 +324,9 @@
                 </div>
             </div>
         </div>
-        
+
         <!-- Console tab content - end -->
-        
+
         <!-- Settings tab content - start -->
         <div class="container main-page-tab-panel" data-tab-panel-id="settings">
             <div class="row">
@@ -347,7 +376,7 @@
                                 </i>
                             </div>
                         </div>
-                    </div>     
+                    </div>
                 </div>
             </div>
         </div>
@@ -411,7 +440,7 @@
                     this firmware. A sample TOML config file can be viewed <a href="https://espressif.github.io/esp-launchpad/config/config.toml"> here </a> </p>
 
                     <p>Rest of the flashing procedure is same easy 4 step process as the Quick Start one above.</p>
-                        
+
                     <p>Once ready, you can use the following image and add following html code on your website for supporting ESPaunchpad with your configuration.
                         Edit the query parameter in the href, replacing URL_TO_YOUR_CONFIG_TOML value where your TOML config file is hosted.
                     </p>
@@ -432,7 +461,7 @@
         </div>
         <!-- About us tab content - end -->
     </div>
-    
+
     <!-- Safari & FireFox not supported error message-->
     <div id="unsupportedBrowserErr" style="display:none"><p align="center" style="color:red">
         This tool is not supported on Safari & Firefox browsers yet! Please try using another browser like Google Chrome.

--- a/js/index.js
+++ b/js/index.js
@@ -38,6 +38,7 @@ const consolePageWrapper = document.getElementById("consolePageWrapper");
 const appConfigInfoContainer = document.getElementById("appConfigInfoContainer");
 const appConfigInfo = document.getElementById("appConfigInfo");
 const progressMsgContainerQS = document.getElementById("progressMsgContainerQS");
+const developKitsContainer = document.getElementById("developKitsContainer");
 
 let resizeTimeout = false;
 
@@ -231,7 +232,7 @@ function populateSupportedDevelopKits(developKitsConfig) {
     developKitsRadioGroup.innerHTML = "";
     let inputElement;
 
-    developKitsConfig.forEach(developKit => {
+    developKitsConfig.forEach((developKit, i) => {
         var div = document.createElement("div");
         div.setAttribute("class", "form-check-inline");
 
@@ -252,15 +253,14 @@ function populateSupportedDevelopKits(developKitsConfig) {
         div.appendChild (lblElement);
 
         developKitsRadioGroup.appendChild(div);
+        if (i === 0) {
+            inputElement.checked = true;
+            var chipTypeButtons = $('input[type="radio"][name="chipType"]:checked');
+            chipTypeButtons.val(inputElement.value);
+        }
     });
 
     developKitsContainer.style.display = "";
-
-    if (developKitsConfig.length === 1) {
-        inputElement.checked = true;
-        var chipTypeButtons = $('input[type="radio"][name="chipType"]:checked');
-        chipTypeButtons.val(inputElement.value);
-    }
 }
 
 function populateSupportedChipsets(deviceConfig) {
@@ -458,10 +458,6 @@ function postConnectControls() {
     lblConnTo.style.display = "block";
 
     $('input:radio[id="radio-' + chip + '"]').prop('checked', true).trigger('change');
-    if (config[deviceTypeSelect.value].developKits?.[chip.toLowerCase()]) {
-        let developKits = config[deviceTypeSelect.value].developKits[chip.toLowerCase()][0];
-        $('input:radio[id="radio-' + developKits + '"]').prop('checked', true).trigger('change');
-    }
 }
 
 connectButton.onclick = async () => {


### PR DESCRIPTION
This version includes the following additions:

1. Optional: Added ESP Develop Kits options for each Application. 
    Different development board models such as esp-box and esp-box3 are displayed based on the selected chipset.

2. Optional: Added a description field for each Application.
    This field allows for a brief introduction of the BIN file, including project links and more.

3. Optional: Integrated README.md rendering below each Application.
    Previously, this feature was only displayed after flashing.
    
![image](https://github.com/espressif/esp-launchpad/assets/68437239/27d53562-01a7-448d-bc1e-06af7bb05001)
