### PR TITLE
Update Esptool-js Version to v0.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,53 +7,16 @@
 			"name": "esp-launchpad",
 			"dependencies": {
 				"crypto-js": "^4.1.1",
-				"esptool-js": "^0.4.1",
+				"esptool-js": "^0.4.5",
 				"smol-toml": "^1.1.2",
 				"xterm": "^4.17.0",
 				"xterm-addon-fit": "^0.5.0"
 			}
 		},
-		"node_modules/base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
-		},
-		"node_modules/buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"dependencies": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
+		"node_modules/atob-lite": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+			"integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw=="
 		},
 		"node_modules/crypto-js": {
 			"version": "4.1.1",
@@ -61,33 +24,14 @@
 			"integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
 		},
 		"node_modules/esptool-js": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.4.1.tgz",
-			"integrity": "sha512-JhPHyjBncwnZDmOWxzjCQV5e6m1qP9kXPsZy5Zn/cu4tBOfPL8McncIzNVCzmLn7Jvgi06Jg09OK2HrkyMSboA==",
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.4.5.tgz",
+			"integrity": "sha512-ueydZt9LIsVCYtPt5q+y0ATnJJA3OflKMPDLUrIG95O5Vi3ZBt80lPh2hghGgSpMv+Whd79zcu4Ty67xFdzAyQ==",
 			"dependencies": {
-				"buffer": "^6.0.3",
+				"atob-lite": "^2.0.0",
 				"pako": "^2.1.0",
 				"tslib": "^2.4.1"
 			}
-		},
-		"node_modules/ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
 		},
 		"node_modules/pako": {
 			"version": "2.1.0",
@@ -123,19 +67,10 @@
 		}
 	},
 	"dependencies": {
-		"base64-js": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-		},
-		"buffer": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-			"requires": {
-				"base64-js": "^1.3.1",
-				"ieee754": "^1.2.1"
-			}
+		"atob-lite": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+			"integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw=="
 		},
 		"crypto-js": {
 			"version": "4.1.1",
@@ -143,19 +78,14 @@
 			"integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
 		},
 		"esptool-js": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.4.1.tgz",
-			"integrity": "sha512-JhPHyjBncwnZDmOWxzjCQV5e6m1qP9kXPsZy5Zn/cu4tBOfPL8McncIzNVCzmLn7Jvgi06Jg09OK2HrkyMSboA==",
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.4.5.tgz",
+			"integrity": "sha512-ueydZt9LIsVCYtPt5q+y0ATnJJA3OflKMPDLUrIG95O5Vi3ZBt80lPh2hghGgSpMv+Whd79zcu4Ty67xFdzAyQ==",
 			"requires": {
-				"buffer": "^6.0.3",
+				"atob-lite": "^2.0.0",
 				"pako": "^2.1.0",
 				"tslib": "^2.4.1"
 			}
-		},
-		"ieee754": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
 		},
 		"pako": {
 			"version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "esp-launchpad",
 	"dependencies": {
 		"crypto-js": "^4.1.1",
-		"esptool-js": "^0.4.1",
+		"esptool-js": "^0.4.5",
 		"smol-toml": "^1.1.2",
 		"xterm": "^4.17.0",
 		"xterm-addon-fit": "^0.5.0"


### PR DESCRIPTION
# What Does This MR Do ?
- It will update the esptool-js package version to 0.4.5 which will add support for P4 chips.

## Test Link ?
- https://rushikeshpatange.github.io/esp-launchpad/