### PR TITLE
Update esptool-js to v0.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
 			"name": "esp-launchpad",
 			"dependencies": {
 				"crypto-js": "^4.1.1",
-				"esptool-js": "^0.4.5",
+				"esptool-js": "^0.4.6",
 				"smol-toml": "^1.1.2",
 				"xterm": "^4.17.0",
 				"xterm-addon-fit": "^0.5.0"
@@ -24,9 +24,9 @@
 			"integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
 		},
 		"node_modules/esptool-js": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.4.5.tgz",
-			"integrity": "sha512-ueydZt9LIsVCYtPt5q+y0ATnJJA3OflKMPDLUrIG95O5Vi3ZBt80lPh2hghGgSpMv+Whd79zcu4Ty67xFdzAyQ==",
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.4.6.tgz",
+			"integrity": "sha512-5Wu3/+9+P8DhJnF513VDilOCoWez3wW2Bcz7tMBefduoCX/PyU/6k33KELRHmvLp4NEOrlb2ktypZwdlnZ6a+A==",
 			"dependencies": {
 				"atob-lite": "^2.0.0",
 				"pako": "^2.1.0",
@@ -78,9 +78,9 @@
 			"integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
 		},
 		"esptool-js": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.4.5.tgz",
-			"integrity": "sha512-ueydZt9LIsVCYtPt5q+y0ATnJJA3OflKMPDLUrIG95O5Vi3ZBt80lPh2hghGgSpMv+Whd79zcu4Ty67xFdzAyQ==",
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.4.6.tgz",
+			"integrity": "sha512-5Wu3/+9+P8DhJnF513VDilOCoWez3wW2Bcz7tMBefduoCX/PyU/6k33KELRHmvLp4NEOrlb2ktypZwdlnZ6a+A==",
 			"requires": {
 				"atob-lite": "^2.0.0",
 				"pako": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "esp-launchpad",
 	"dependencies": {
 		"crypto-js": "^4.1.1",
-		"esptool-js": "^0.4.5",
+		"esptool-js": "^0.4.6",
 		"smol-toml": "^1.1.2",
 		"xterm": "^4.17.0",
 		"xterm-addon-fit": "^0.5.0"


### PR DESCRIPTION
# What Does This MR Do ?
- It will update the esptool-js package version to 0.4.6 which will add support for C5 chips.

## Test Link ?
- https://rushikeshpatange.github.io/esp-launchpad/