### PR TITLE
Make use of the rainmaker example firmware images build from the GitHub

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -89,15 +89,15 @@ var isDefault = true;
 // Build the Quick Try UI using the config toml file. If external path is not specified, pick up the default config
 async function buildQuickTryUI() {
     const urlParams = new URLSearchParams(window.location.search);
-    var tomlFileURL = window.location.origin + window.location.pathname + "config/rainmaker_config.toml"; // defaulting to rainmaker for now.
+    var tomlFileURL = "https://espressif.github.io/esp-rainmaker/launchpad.toml"; // defaulting to rainmaker for now.
     var solution = urlParams.get("solution");
     if (solution){
         if (solution.toLowerCase() == "matter")
             // use the one published by the ci/cd job of matter on the github
             tomlFileURL = "https://espressif.github.io/esp-matter/launchpad.toml";
         else if(solution.toLowerCase() == "rainmaker")
-            // use the one bundled in the config
-            tomlFileURL = window.location.origin + window.location.pathname + "config/rainmaker_config.toml";
+            // use the one published by ci/cd job of rainmaker on the github
+            tomlFileURL = "https://espressif.github.io/esp-rainmaker/launchpad.toml";
     }
     else {
         var externalURL = urlParams.get('flashConfigURL');


### PR DESCRIPTION

## Description

RainMaker CI/CD job generates firmware images (combined into one single binary) for each of the examples. A toml file is also auto-generated for these supported examples. This change makes use of the generated toml file which in turn makes use of the generated latest firmware images.