### PR TITLE
Allowing image offset to be specified in config.toml (fixes issue #48)

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -676,11 +676,12 @@ programButton.onclick = async () => {
 
 async function downloadAndFlash(fileURL) {
     let data = await utilities.getImageData(fileURL);
+    let offset = parseInt(config[deviceTypeSelect.value].offset ?? "0x0000");
     try {
         if (data !== undefined) {
             $('#v-pills-console-tab').click();
             const flashOptions = {
-                fileArray : [{data:data, address:0x0000}],
+		fileArray : [{data:data, address:offset}],
                 flashSize: "keep",
                 flashMode: undefined,
                 flashFreq: undefined,
@@ -688,7 +689,9 @@ async function downloadAndFlash(fileURL) {
                 compress: true,
             };
             await esploader.writeFlash(flashOptions);
-        }
+        } else {
+	    alert("Image file not found");
+	}
     } catch (e) {
     }
 }


### PR DESCRIPTION
## Description

Modified function `downloadAndFlash` to handle image offset.
Image offset should be added to config.toml inside the section of the corresponding app. If offset is not specified it defaults to zero.
Also, added an alert if the image file is not found, because otherwise there is no warning to the user (but this should also be handled outside this function, to disable the flashing complete message).

## Related

Fixes #48 (Add a way to specify an offset in config.toml)

Example of (partial) config.toml, with offset 0x10000:

```
# Apps that you support and for which the binaries are available to publish. You can have multiple apps as a comma separated list
# The launch pad UI will automatically show these Apps in the available apps dropdown
# There should be a config section per listed App
supported_apps = ["example_app"]

...

[example_app]
# ESP32 Chipsets for which you have a supported Firmware App. Define a property for each supported chipset in the given format.
chipsets = ["ESP32", "ESP32-S2", "ESP32-C3", "ESP32-S3"]
# Starting address for firmware flashing
offset = "0x10000"
# Configure the name of the binary file
image.esp32 = "example.bin"

```

## TBD

Remove alert when image file not found, and handle it outside this function.
