### PR TITLE
Update esptool-js to v0.5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
 			"name": "esp-launchpad",
 			"dependencies": {
 				"crypto-js": "^4.1.1",
-				"esptool-js": "^0.4.7",
+				"esptool-js": "^0.5.4",
 				"smol-toml": "^1.1.2",
 				"xterm": "^4.17.0",
 				"xterm-addon-fit": "^0.5.0"
@@ -24,9 +24,10 @@
 			"integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
 		},
 		"node_modules/esptool-js": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.4.7.tgz",
-			"integrity": "sha512-xVwtSVDRsvjXSEvNFrorgJfB71RFFkZkL+hs7O7gW5hgPrKGywZxo2U5LJddzkJ6eE31QinNVyywc0OaSntZCw==",
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.5.4.tgz",
+			"integrity": "sha512-B+XcbbPBjfmnMHVGktGlNI85BbEIQs02y4hoYuqM25q6yVPqLE3bxce/KWtKXH4IGruWTkEujqdKxNeWEV2BDg==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"atob-lite": "^2.0.0",
 				"pako": "^2.1.0",
@@ -78,9 +79,9 @@
 			"integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
 		},
 		"esptool-js": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.4.7.tgz",
-			"integrity": "sha512-xVwtSVDRsvjXSEvNFrorgJfB71RFFkZkL+hs7O7gW5hgPrKGywZxo2U5LJddzkJ6eE31QinNVyywc0OaSntZCw==",
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.5.4.tgz",
+			"integrity": "sha512-B+XcbbPBjfmnMHVGktGlNI85BbEIQs02y4hoYuqM25q6yVPqLE3bxce/KWtKXH4IGruWTkEujqdKxNeWEV2BDg==",
 			"requires": {
 				"atob-lite": "^2.0.0",
 				"pako": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "esp-launchpad",
 	"dependencies": {
 		"crypto-js": "^4.1.1",
-		"esptool-js": "^0.4.7",
+		"esptool-js": "^0.5.4",
 		"smol-toml": "^1.1.2",
 		"xterm": "^4.17.0",
 		"xterm-addon-fit": "^0.5.0"


### PR DESCRIPTION
## Description:
### What Does This MR Do ?
- Upgrade esptool-js to the 0.5.4 for improved compatibility of devices and performance.
- Enhanced device data reading functionality needed on resetting device.

## Related:
- After upgrading **esptool-js** version in **esp-launchpad** there was an issue while resetting the device, which will get fix by this PR.

## Testing:

### 🛠 Test Details  

| Test Link | Tested Chips |
|-----------|-------------|
| [ESP Launchpad](https://rushikeshpatange.github.io/esp-launchpad/) | - ESP32-C3<br>- ESP32-C61 |

---

## Checklist:

Ensured the following points:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
