### PR TITLE
Remove the '-' from app filtering logic to support more generic app filtering .

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -113,9 +113,14 @@ async function buildQuickTryUI() {
         if (xhr.readyState === 4 && xhr.status === 200) {
             config = toml.parse(xhr.responseText);
             var requestedApp = urlParams.get("app");
+            var exactMatch = urlParams.get("exact") === "true";
             if (requestedApp) {
-                // Filter the supported_apps that start with the app name
-                const filtered_apps = config.supported_apps.filter(app => app.startsWith(`${requestedApp}-`));
+               // Filter supported_apps by exact name if 'exact' is true; otherwise, match apps that start with the requested name
+               const filtered_apps = config.supported_apps.filter(app => {
+                    return exactMatch
+                        ? app === requestedApp
+                        : app.startsWith(`${requestedApp}`);
+                });
 
                 if (filtered_apps.length > 0) {
                     config["supported_apps"] = filtered_apps;


### PR DESCRIPTION
**Problem**
- The existing app filtering logic in buildQuickTryUI() was filtering supported_apps based on a pattern match using startsWith() containing a '-'.
- As a result, only apps whose names followed a specific prefix pattern were being retained, and valid apps not matching this pattern were unintentionally excluded from the selection.

**Change Overview**
- Removed the '-' from the filtering logic to more generically support filtering.
- Now, when an app value is passed via the URL, the UI will filter supported_apps by exact match or the apps starting with a particular pattern. So, apps not having a '-' will also get filtered correctly.
- If no matching app is found, an alert is shown indicating that no applications were found for the requested app name.

 **Testing**
- Tested locally on a development server by providing a flashConfigURL pointing to a local TOML file along with different app values in the query string.
- Tested on the GitHub Pages deployment (via GitHub Actions) with both existing and non-existing app values to verify:
     i) Correct apps are retained in the config when present.
     ii)Appropriate alert is displayed when the requested app is not found.
 
 **Before the app filtering logic**
![Screenshot from 2025-06-25 12-40-10](https://github.com/user-attachments/assets/b6e30776-96fd-4901-b96c-a51e06307fc4)

 **Post the app filtering logic**
![Screenshot from 2025-06-25 12-39-22](https://github.com/user-attachments/assets/4781edf8-5f21-4114-a4d3-52a4e93212cc)
