### PR TITLE
feat: Support accessing cross-domain artifact references using the espressif CORS proxy server

### DIFF
--- a/index.html
+++ b/index.html
@@ -477,6 +477,27 @@
                             </textarea>
                         </div>
                     </div>
+                    <div style="margin-top: 20px;">
+                        <h4 class="mb-4" style="color: #e63f36;"><b>Using CORS Proxy for External TOML Files</b></h4>
+                        <p>If your TOML configuration file is hosted on a server that doesn't support CORS (Cross-Origin Resource Sharing), 
+                        or if you want to load a file from your local PC or from a source other than <code>espressif.github.io</code>, 
+                        simply add <code>&crossDomain=true</code> to your URL. The CORS proxy will be applied automatically.</p>
+                        
+                        <p><b>URL Format:</b> Add <code>&crossDomain=true</code> to your <code>flashConfigURL</code>:</p>
+                        <textarea readonly cols="160" rows="2">https://espressif.github.io/esp-launchpad/?flashConfigURL=YOUR_CONFIG_TOML_URL&crossDomain=true</textarea>
+                        
+                        <p style="margin-top: 15px;"><b>Loading from your local PC:</b></p>
+                        <p>To load a TOML file from your local machine, you need to expose it via a tunnel service (e.g., Cloudflare Tunnel, ngrok, or similar). 
+                        Once your local server is accessible via a public URL, use it with <code>&crossDomain=true</code>:</p>
+                        <textarea readonly cols="160" rows="2">https://espressif.github.io/esp-launchpad/?flashConfigURL=https://your-tunnel-url.trycloudflare.com/config.toml&crossDomain=true</textarea>
+                        
+                        <p style="margin-top: 15px;"><b>Loading from a custom server:</b></p>
+                        <p>If your TOML file is hosted on your own server (e.g., <code>https://mycompany.com</code>):</p>
+                        <textarea readonly cols="160" rows="2">https://espressif.github.io/esp-launchpad/?flashConfigURL=https://mycompany.com/firmware/config.toml&crossDomain=true</textarea>
+                        
+                        <p style="margin-top: 15px;"><b>Note:</b> When using an external TOML source, a message will be displayed: 
+                        <i>"You have chosen to try the firmware images from an external source"</i> along with the URL of your configuration file.</p>
+                    </div>
                 </div>
             </div>
         </div>

--- a/js/index.js
+++ b/js/index.js
@@ -104,6 +104,10 @@ async function buildQuickTryUI() {
     else {
         var externalURL = urlParams.get('flashConfigURL');
         if(externalURL){
+            var crossDomain = urlParams.get('crossDomain') === 'true';
+            if (crossDomain) {
+                externalURL = 'https://cors-proxy.espressif.tools/?url=' + externalURL;
+            }
             tomlFileURL = externalURL;
             isDefault = false;
         }


### PR DESCRIPTION
## Description

Added `crossDomain=true` URL query parameter support to enable loading TOML configuration files from external sources that don't support CORS.

Previously, there was no support for loading TOML files from cross-origin servers. Now, users can add `&crossDomain=true` to their URL, and the Espressif CORS proxy (`cors-proxy.espressif.tools`) is automatically prepended in the LaunchPad code.

### Changes:

- **`js/index.js`**: Added logic to detect the `crossDomain=true` query parameter and automatically prepend `https://cors-proxy.espressif.tools/?url=` to the `flashConfigURL`
- **`index.html`**: Added documentation in the About section explaining the `crossDomain=true` usage for external TOML files

### Example usage:

`?flashConfigURL=https://mycompany.com/config.toml&crossDomain=true`

## Related

- Fixes: https://github.com/espressif/esp-launchpad/issues/12
- CORS proxy deployment: https://cors-proxy.espressif.tools/

## Testing

- Verified the `crossDomain=true` parameter is correctly parsed and the CORS proxy URL is automatically prepended
- Tested with an external TOML file using `&crossDomain=true` - CORS proxy is applied correctly

---

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.

## The change
<img width="1108" height="754" alt="esp-launchpad-addition" src="https://github.com/user-attachments/assets/81f62673-b9a4-4b0c-97ac-93d49bae63b0" />

## Local Test

Tested with an external TOML file using `&crossDomain=true` - CORS proxy is applied correctly.
