### PR TITLE
Update esptool-js to v0.6.0

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -66,7 +66,6 @@ term.loadAddon(fitAddon);
 term.open(terminal);
 fitAddon.fit();
 
-let reader = undefined;
 let device = null;
 let transport = undefined;
 let chip = "default";
@@ -527,6 +526,7 @@ resetButton.onclick = async () => {
     postFlashClick();
     consoleStartButton.disabled = false;
     $('#closeResetModal').click();
+    await utilities.stopConsoleRead();
     if (transport) {
         await transport.disconnect();
     }
@@ -536,19 +536,7 @@ resetButton.onclick = async () => {
     await transport.setDTR(false);
     await new Promise(resolve => setTimeout(resolve, 100));
     await transport.setDTR(true);
-    while (true && connected) {
-        try {
-            const readLoop = transport.rawRead();
-            const { value, done } = await readLoop.next();
-            
-            if (done || !value) {
-                break;
-            }
-            term.write(value);   
-        } catch (error) {
-            term.writeln(`Error: ${error.message}`);
-        }
-      }
+    await utilities.startConsoleRead(device, term, () => connected);
 }
 
 eraseButton.onclick = async () => {
@@ -601,13 +589,15 @@ function cleanUp() {
     device = null;
     transport = undefined;
     chip = "default";
-    reader = undefined;
     isFlashByDIYMode = false;
     isFlashByQuickTryMode = false;
 }
 
 disconnectButton.onclick = async () => {
     connected = false;
+    // Must run before transport.disconnect(): it waits for the readable stream
+    // to unlock, which never happens while the console loop has a read() pending.
+    await utilities.stopConsoleRead();
     if(transport){
         await transport.disconnect();
     }

--- a/js/utils.js
+++ b/js/utils.js
@@ -23,18 +23,12 @@ export function getImageData(fileURL) {
     return new Promise(resolve => {
         var xhr = new XMLHttpRequest();
         xhr.open('GET', fileURL, true);
-        xhr.responseType = "blob";
+        // esptool-js >= 0.6.0 expects Uint8Array image data in writeFlash
+        xhr.responseType = "arraybuffer";
         xhr.send();
         xhr.onload = function () {
             if (xhr.readyState === 4 && xhr.status === 200) {
-                var blob = new Blob([xhr.response], { type: "application/octet-stream" });
-                var reader = new FileReader();
-                reader.onload = (function (theFile) {
-                    return function (e) {
-                        resolve(e.target.result);
-                    };
-                })(blob);
-                reader.readAsBinaryString(blob);
+                resolve(new Uint8Array(xhr.response));
             } else {
                 resolve(undefined);
             }
@@ -43,6 +37,57 @@ export function getImageData(fileURL) {
             resolve(undefined);
         }
     });
+}
+
+// -----------------------------------------------------------------------------
+// Console read loop (shared by launchpad and minimal-launchpad).
+// Owns its reader (unlike esptool-js 0.6.0 transport.rawRead, which keeps the
+// reader private) so stopConsoleRead() can cancel a pending read. Without this,
+// transport.disconnect() blocks forever in waitForUnlock() while the console is
+// idle: it can only cancel its own internal reader (used during flashing).
+// -----------------------------------------------------------------------------
+
+/** Reader owned by the active console read loop; cancelled via stopConsoleRead(). */
+let consoleReader = undefined;
+
+/**
+ * Read from the device and write to the terminal until isActive() returns false,
+ * the stream ends, or stopConsoleRead() cancels the pending read.
+ * @param {SerialPort} device Serial port to read from (its readable stream must be unlocked)
+ * @param {Terminal} term xterm.js terminal to write device output to
+ * @param {() => boolean} isActive Keep reading while this returns true
+ */
+export async function startConsoleRead(device, term, isActive) {
+    try {
+        consoleReader = device.readable.getReader();
+        while (isActive()) {
+            const { value, done } = await consoleReader.read();
+            if (done || !value) {
+                break;
+            }
+            term.write(value);
+        }
+    } catch (error) {
+        term.writeln(`Error: ${error.message}`);
+    } finally {
+        consoleReader?.releaseLock();
+        consoleReader = undefined;
+    }
+}
+
+/**
+ * Cancel the active console reader (if any) so its pending read() resolves and
+ * the readable-stream lock is released. Call before transport.disconnect()
+ * whenever a console read loop may be running.
+ */
+export async function stopConsoleRead() {
+    if (consoleReader) {
+        try {
+            await consoleReader.cancel();
+        } catch (error) {
+            console.error(`[esp-launchpad] stopConsoleRead: cancel failed: ${error.message}`);
+        }
+    }
 }
 
 export const initializeTooltips = function () {
@@ -83,12 +128,13 @@ export function handleFileSelect(evt) {
 
     reader.onload = (function (theFile) {
         return function (e) {
-            file1 = e.target.result;
+            // esptool-js >= 0.6.0 expects Uint8Array image data in writeFlash
+            file1 = new Uint8Array(e.target.result);
             evt.target.data = file1;
         };
     })(file);
 
-    reader.readAsBinaryString(file);
+    reader.readAsArrayBuffer(file);
 }
 
 /** Whether `navigator.serial` is exposed */

--- a/minimal-launchpad/minimal_ui_index.js
+++ b/minimal-launchpad/minimal_ui_index.js
@@ -386,6 +386,7 @@ connectButton.onclick = async () => {
 }
 
 consoleStartButton.onclick = async () => {
+    await utilities.stopConsoleRead();
     if (transport) {
         await transport.disconnect();
     }
@@ -398,20 +399,7 @@ consoleStartButton.onclick = async () => {
     await transport.setDTR(false);
     await new Promise(resolve => setTimeout(resolve, 100));
     await transport.setDTR(true);
-
-    while (true && connected) {
-        try {
-            const readLoop = transport.rawRead();
-            const { value, done } = await readLoop.next();
-
-            if (done || !value) {
-                break;
-            }
-            term.write(value);
-        } catch (error) {
-            term.writeln(`Error: ${e.message}`);
-        }
-    }
+    await utilities.startConsoleRead(device, term, () => connected);
 }
 
 async function sendCommand() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 		"": {
 			"name": "esp-launchpad",
 			"dependencies": {
-				"esptool-js": "^0.5.4",
+				"esptool-js": "^0.6.0",
 				"smol-toml": "^1.6.1",
 				"xterm": "^4.17.0",
 				"xterm-addon-fit": "^0.5.0"
@@ -18,9 +18,9 @@
 			"integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw=="
 		},
 		"node_modules/esptool-js": {
-			"version": "0.5.4",
-			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.5.4.tgz",
-			"integrity": "sha512-B+XcbbPBjfmnMHVGktGlNI85BbEIQs02y4hoYuqM25q6yVPqLE3bxce/KWtKXH4IGruWTkEujqdKxNeWEV2BDg==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.6.0.tgz",
+			"integrity": "sha512-ZyuSBXvmS+4DRKM6GrDHfCscnq3YSNlRfM+Zw0DoS7uC3SdkyC262s/ji4MjDYVmMH8SE2BiYx3/dZ1J23Xiew==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"atob-lite": "^2.0.0",
@@ -71,9 +71,9 @@
 			"integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw=="
 		},
 		"esptool-js": {
-			"version": "0.5.4",
-			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.5.4.tgz",
-			"integrity": "sha512-B+XcbbPBjfmnMHVGktGlNI85BbEIQs02y4hoYuqM25q6yVPqLE3bxce/KWtKXH4IGruWTkEujqdKxNeWEV2BDg==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.6.0.tgz",
+			"integrity": "sha512-ZyuSBXvmS+4DRKM6GrDHfCscnq3YSNlRfM+Zw0DoS7uC3SdkyC262s/ji4MjDYVmMH8SE2BiYx3/dZ1J23Xiew==",
 			"requires": {
 				"atob-lite": "^2.0.0",
 				"pako": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "esp-launchpad",
 	"dependencies": {
-		"esptool-js": "^0.5.4",
+		"esptool-js": "^0.6.0",
 		"smol-toml": "^1.6.1",
 		"xterm": "^4.17.0",
 		"xterm-addon-fit": "^0.5.0"


### PR DESCRIPTION
## Description

This PR upgrades **esptool-js** to **v0.6.0** and updates the consumer implementation to align with the latest API changes.

### Changes

* Upgrade **esptool-js** to **v0.6.0** to add support for **ESP32-C5 eco2** chip detection.
* Adapt to the **v0.6.0** API changes for flashing and console reading.
* Refactor console reading to prevent transport disconnect deadlocks.
* Enhance console error handling.

## Related

- Test Link: https://rushikeshpatange.github.io/esp-launchpad

## Testing

* Verified flashing workflow with the updated `writeFlash()` API.
* Verified console reading with the updated changes.
* Verified successful ESP32-C5 eco2 chip detection.

---

## Checklist

Before submitting a Pull Request, please ensure the following:

* [x] 🚨 This PR does not introduce breaking changes.
* [x] Code is well-commented, especially in complex areas.
* [x] Git history is clean — commits are kept minimum as necessary.