### PR TITLE
Feature: Add an entry point for manually downloading the corresponding firmware

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -332,6 +332,11 @@ td img {
     margin-left: 18px;
 }
 
+.firmware-download-trigger-container {
+    padding-top: 14px;
+    margin-left: 18px;
+}
+
 @media (min-width: 1400px) {
     .container-xxl, .container-xl, .container-lg, .container-md, .container-sm, .container {
       max-width: 1320px;

--- a/index.html
+++ b/index.html
@@ -245,6 +245,30 @@
                             <div id="appInfoTriggerContainer" class="field-container app-info-trigger-container" style="display: none;">
                                 <a href="#" role="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasRight" aria-controls="offcanvasRight">Show Application Information</a>
                             </div>
+                            <div id="firmwareDownloadTriggerContainer" class="field-container firmware-download-trigger-container" style="display: none;">
+                                <a href="#" role="button" data-bs-toggle="modal" data-bs-target="#firmwareDownloadModal">Download Firmware File</a>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal fade" id="firmwareDownloadModal" tabindex="-1" aria-labelledby="firmwareDownloadModalLabel" aria-hidden="true">
+                        <div class="modal-dialog">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <h4 class="modal-title" id="firmwareDownloadModalLabel"><span style="color: #17a2b8;">Download Firmware File</span></h4>
+                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                </div>
+                                <div class="modal-body">
+                                    <p>Download the firmware and flash it manually using the
+                                        <a href="https://docs.espressif.com/projects/esp-test-tools/en/latest/esp32/production_stage/tools/flash_download_tool.html" target="_blank" rel="noopener">Flash Download Tool</a>
+                                        or
+                                        <a href="https://docs.espressif.com/projects/esptool/en/latest/esp32/esptool/basic-commands.html#write-binary-data-to-flash-write-flash" target="_blank" rel="noopener">esptool</a>.
+                                        Refer to their documentation for detailed instructions.
+                                    </p>
+                                </div>
+                                <div class="modal-footer">
+                                    <a class="app-button btn btn-outline-dark" id="firmwareDownloadButton" href="#" target="_blank" rel="noopener" download>Download Firmware</a>
+                                </div>
+                            </div>
                         </div>
                     </div>
                     <div class="offcanvas offcanvas-end w-50" tabindex="-1" id="offcanvasRight" aria-labelledby="offcanvasRightLabel">

--- a/js/index.js
+++ b/js/index.js
@@ -45,6 +45,8 @@ const appConfigInfo = document.getElementById("appConfigInfo");
 const progressMsgContainerQS = document.getElementById("progressMsgContainerQS");
 const developKitsContainer = document.getElementById("developKitsContainer");
 const appInfoTriggerContainer = document.getElementById("appInfoTriggerContainer");
+const firmwareDownloadTriggerContainer = document.getElementById("firmwareDownloadTriggerContainer");
+const firmwareDownloadButton = document.getElementById("firmwareDownloadButton");
 const rightOffCanvasContainer = document.getElementById("offcanvasRight");
 
 let resizeTimeout = false;
@@ -252,6 +254,7 @@ async function buildQuickTryUI_v1_0() {
     }
 
     setAppURLs(config[supported_apps[0]]);
+    updateFirmwareDownloadLink();
 }
 
 function addDeviceTypeOption(apps) {
@@ -385,12 +388,14 @@ $('#chipsets').on('change', 'input[type="radio"][name="chipType"]',function() {
         developKitsContainer.style.display = "none";
     }
 
+    updateFirmwareDownloadLink();
 });
 
 $('#developKits').on('change', 'input[type="radio"][name="developKitsType"]',function() {
     var selectedValue = $('input[type="radio"][name="developKitsType"]:checked').val();
     var chipTypeButtons = $('input[type="radio"][name="chipType"]:checked');
     chipTypeButtons.val(selectedValue);
+    updateFirmwareDownloadLink();
 });
 
 function setAppURLs(appConfig) {
@@ -400,10 +405,24 @@ function setAppURLs(appConfig) {
     setup_qrcode_payload = appConfig.setup_payload;
 }
 
+function updateFirmwareDownloadLink() {
+    const selectedFirmwareFile = $('input[type="radio"][name="chipType"]:checked').val();
+    if (selectedFirmwareFile && config.firmware_images_url) {
+        firmwareDownloadButton.href = /^https?:\/\//i.test(selectedFirmwareFile)
+            ? selectedFirmwareFile
+            : `${config.firmware_images_url.replace(/\/+$/, '')}/${selectedFirmwareFile.replace(/^\/+/, '')}`;
+        firmwareDownloadTriggerContainer.style.display = '';
+    } else {
+        firmwareDownloadButton.href = '#';
+        firmwareDownloadTriggerContainer.style.display = 'none';
+    }
+}
+
 $('#frameworkSel').on('change', function() {
     //populateDeviceTypes(config[frameworkSelect.value]);
     addDeviceTypeOption(config["supported_apps"], frameworkSelect.value);
     setAppURLs(frameworkSelect.value);
+    updateFirmwareDownloadLink();
 });
 
 $('#device').on('change', function() {
@@ -441,6 +460,7 @@ $('#device').on('change', function() {
     if (config[deviceTypeSelect.value].console_baudrate) {
         consoleBaudrateFromToml = config[deviceTypeSelect.value].console_baudrate;
     }
+    updateFirmwareDownloadLink();
 });
 
 $(function () {


### PR DESCRIPTION
## Description

Add an entry point for manually downloading the corresponding firmware.

Due to browser compatibility and other environmental factors, we cannot guarantee that Launchpad will work as expected for every user. Some users already have Flash Download Tool installed or are familiar with esptool, and may prefer to manually download and flash the firmware as an alternative.

## Checklist

Before submitting a Pull Request, please ensure the following:

- [x] 🚨 This PR does not introduce breaking changes.
- [ ] All CI checks (GH Actions) pass.
- [ ] Documentation is updated as needed.
- [ ] Tests are updated or added as necessary.
- [ ] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
